### PR TITLE
Fix undefined glassmorphic container

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'dart:ui';
 import 'dart:math' as math;
 import '../main.dart';
+import '../widgets/glassmorphic_container.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});

--- a/lib/widgets/glassmorphic_container.dart
+++ b/lib/widgets/glassmorphic_container.dart
@@ -30,11 +30,11 @@ class GlassmorphicContainer extends StatelessWidget {
           width: width,
           height: height,
           decoration: BoxDecoration(
-            color: theme.colorScheme.surface.withValues(alpha: 0.15),
+            color: theme.colorScheme.surface.withOpacity(0.15),
             borderRadius: BorderRadius.circular(borderRadius),
             border: Border.all(
               width: border,
-              color: theme.colorScheme.primary.withValues(alpha: 0.2),
+              color: theme.colorScheme.primary.withOpacity(0.2),
             ),
           ),
           child: child,


### PR DESCRIPTION
Fix `GlassmorphicContainer` errors by adding a missing import and updating a color method for compatibility.

The original build failed because `GlassmorphicContainer` was not recognized in `profile_screen.dart` due to a missing import. Additionally, the `withValues` method used for color manipulation in `GlassmorphicContainer` was causing compatibility issues with Flutter versions, which has been replaced with `withOpacity`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a109e793-97d1-4740-b86a-e8c93fb04a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a109e793-97d1-4740-b86a-e8c93fb04a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

