### PR TITLE
Fix undefined glassmorphic container

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:around_you/widgets/glassmorphic_container.dart';
 
 import 'dart:ui';
 import 'dart:math' as math;


### PR DESCRIPTION
Add missing import for `GlassmorphicContainer` to resolve undefined method errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0db14c2-d740-4ed0-a5df-56bf1f82d108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0db14c2-d740-4ed0-a5df-56bf1f82d108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

